### PR TITLE
Add DENTNet meetadata portal link

### DIFF
--- a/public/portals.json
+++ b/public/portals.json
@@ -6,5 +6,9 @@
   "parity": {
     "name": "Parity",
     "url": "https://metadata.parity.io/"
+  },
+  "dentnet": {
+    "name": "DENTNet",
+    "url": "https://main.dentnet.io/vault/"
   }
 }


### PR DESCRIPTION
Waiting when DENTNet will add a metadata portal selector on their metadata portal https://main.dentnet.io/vault/?tab=0#/dentnet